### PR TITLE
Add Workflow to automatically push new versions to AUR

### DIFF
--- a/.github/workflows/publish-to-aur.yaml
+++ b/.github/workflows/publish-to-aur.yaml
@@ -1,0 +1,42 @@
+name: Publish to AUR
+on:
+  release:
+    types: [released]
+jobs:
+  Publish-to-AUR:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Get PKGBUILD from repo"
+        uses: Bhacaz/checkout-files@v1
+        with:
+          files: AUR/PKGBUILD
+          token: ${{ github.token }}
+      - name: "Get latest release"
+        id: latestrelease
+        uses: InsonusK/get-latest-release@v1.0.1
+        with:
+          myToken: ${{ github.token }}
+          exclude_types: "draft|prerelease"
+          view_top: 1
+      - name: "Update PKGVER in PKGBUILD"
+        run: sed -i '/pkgver=/s/$/'$(echo '${{ steps.latestrelease.outputs.tag_name }}' |  sed 's/v//g')'/' AUR/PKGBUILD
+      - name: "Update PKGBUILD Checksums and generate SRCINFO"
+        uses: datakrama/archlinux-package-action@v1.0.3
+        with:
+          path: AUR/    
+          updpkgsums: true
+          srcinfo: true
+          namcap: false
+          flags: ''
+      - run: cat AUR/PKGBUILD
+      - run: cat AUR/.SRCINFO
+      - name: "Push to AUR"
+        uses: KSXGitHub/github-actions-deploy-aur@v2.2.5
+        with:
+          pkgname: emusak-bin
+          pkgbuild: AUR/PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: Update to ${{ steps.latestrelease.outputs.tag_name }}
+          ssh_keyscan_types: rsa,dsa,ecdsa,ed25519

--- a/AUR/PKGBUILD
+++ b/AUR/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: LiveLM <livelm at hotmail dot com> 
+# Maintainer: CptSparrow < discordbotdupont at protonmail dot com >
+pkgname=emusak-bin
+pkgver=
+pkgrel=1
+pkgdesc="Allows you to download saves and shaders for Switch emulators."
+arch=(x86_64)
+url="https://github.com/stromcon/emusak-ui"
+license=('GPL3')
+depends=(expat glib2 nss gtk3)
+source=("https://github.com/stromcon/emusak-ui/releases/download/v$pkgver/emusak_${pkgver}_amd64.deb")
+sha256sums=('9263e7ea384a1148834b7de0f46ce9ae1066c2eb393cb506de7e6f29f1141f8b')
+
+build(){
+	tar -xvf data.tar.xz
+}
+
+package() {
+	cp -r usr "$pkgdir"
+}

--- a/Readme.md
+++ b/Readme.md
@@ -26,9 +26,13 @@ install the software just by executing the `.exe` file. You can remove the softw
 
 Download deb file then `sudo dpkg -i ./emusak-ui-X.Y_amd64.deb`
 
+##### Arch Linux
+
+Download [emusak-bin from the AUR](https://aur.archlinux.org/packages/emusak-bin/) and install it with `makepkg -si` or use your favorite AUR helper.
+
 ##### All distros
 
-There is also an `AppImage`,  I'll create a ppa and aur package for linux users soon
+There is also an `AppImage`,  I'll create a ppa for linux users soon
 
 ### Features
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -103,7 +103,7 @@ const App = () => {
         {
           (version !== latestRelease && latestRelease && process.platform !== "win32") && (
             <div style={{ padding: 20 }}>
-              <Alert severity="info">You have version v{version}, please consider update to latest version from <a href="#" onClick={() => electron.shell.openExternal("https://github.com/stromcon/emusak-ui")}>Github</a> (v{latestRelease})</Alert>
+              <Alert severity="info">You have version v{version}, please consider updating to the latest version from <a href="#" onClick={() => electron.shell.openExternal("https://github.com/stromcon/emusak-ui")}>Github</a> or the <a href="#" onClick={() => electron.shell.openExternal("https://aur.archlinux.org/packages/emusak-bin/")}>AUR</a> (v{latestRelease})</Alert>
             </div>
           )
         }


### PR DESCRIPTION
Whenever a new version is released, this Github Workflow will automatically grab the .deb file, update the PKGBUILD and will upload the new version to the AUR.  
It will only run when a new version is tagged and released, it will not act on pre-releases or drafted releases.  
This PR also adds the AUR link to the Readme.